### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Based on convention, EF will look for a connection strign named as the DBContext
 
 **0.7**
 
- * Added DateTime editor template to be able to edit datetime fields accross de application
+ * Added DateTime editor template to be able to edit datetime fields across de application
  * Added jQuery UI calendar functionality to datetime editor fields.
  * Set PAID / UNPAID display as text with style instead of checkbox
 


### PR DESCRIPTION
@iloire, I've corrected a typographical error in the documentation of the [asp.net-mvc-example-invoicing-app](https://github.com/iloire/asp.net-mvc-example-invoicing-app) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.